### PR TITLE
sepolicy: Remove duplicate property definition

### DIFF
--- a/qva/public/property.te
+++ b/qva/public/property.te
@@ -26,7 +26,6 @@
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 system_restricted_prop(vendor_persist_dpm_prop)
-system_restricted_prop(vendor_persist_camera_prop)
 
 # this is vendor defined property  and added with prefix vendor
 # which is going to be working from system


### PR DESCRIPTION
vendor_persist_camera_prop is already declared in Lineage sepolicy

Change-Id: Idfc24a85c7654796cdb243443953a8e0bfb28b0a